### PR TITLE
Add snack request submission page and admin controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Snack request workflow
+
+- Authenticated members can visit `/requests` to submit snack ideas and track the status of their previous suggestions.
+- Admins review, filter, and update those submissions from the `/admin` panel.
+- Snack requests are stored in the `snack_requests` table. Apply the SQL in `supabase/migrations/20240227000000_create_snack_requests.sql` to your Supabase instance to provision the table and indexes before using the new flow.

--- a/src/app/api/snack-requests/[id]/route.ts
+++ b/src/app/api/snack-requests/[id]/route.ts
@@ -1,0 +1,103 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import {
+  isValidSnackRequestStatus,
+  toSnackRequest,
+  type SnackRequestRow,
+} from "@/lib/snackRequests";
+
+type UpdatePayload = {
+  status?: unknown;
+};
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return NextResponse.json(
+      { error: "You must be signed in to update a snack request." },
+      { status: 401 }
+    );
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle<{ role: string | null }>();
+
+  if (profileError) {
+    console.error("[snack-requests][PATCH] Failed to fetch admin role", profileError);
+    return NextResponse.json(
+      { error: "We couldn’t verify your access to update snack requests." },
+      { status: 500 }
+    );
+  }
+
+  if (profile?.role !== "admin") {
+    return NextResponse.json(
+      { error: "Only admins can update snack request statuses." },
+      { status: 403 }
+    );
+  }
+
+  let payload: UpdatePayload;
+  try {
+    payload = (await request.json()) as UpdatePayload;
+  } catch (err) {
+    console.error("[snack-requests][PATCH] Invalid JSON payload", err);
+    return NextResponse.json(
+      { error: "We couldn’t read your update. Please try again." },
+      { status: 400 }
+    );
+  }
+
+  const status = typeof payload.status === "string" ? payload.status.trim() : "";
+
+  if (!isValidSnackRequestStatus(status)) {
+    return NextResponse.json(
+      {
+        error: `Status must be one of: pending, accepted, fulfilled, or declined.`,
+      },
+      { status: 400 }
+    );
+  }
+
+  const { data, error: updateError } = await supabase
+    .from("snack_requests")
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq("id", params.id)
+    .select(
+      "id, user_id, snack_name, details, source, status, created_at, updated_at, profiles(full_name, email)"
+    )
+    .maybeSingle();
+
+  if (updateError) {
+    console.error("[snack-requests][PATCH] Failed to update status", updateError);
+    return NextResponse.json(
+      { error: "We couldn’t update that request. Please try again." },
+      { status: 500 }
+    );
+  }
+
+  if (!data) {
+    return NextResponse.json(
+      { error: "That snack request could not be found." },
+      { status: 404 }
+    );
+  }
+
+  const requestRecord = toSnackRequest(data as SnackRequestRow);
+
+  return NextResponse.json({ data: requestRecord });
+}
+
+export const dynamic = "force-dynamic";

--- a/src/app/api/snack-requests/route.ts
+++ b/src/app/api/snack-requests/route.ts
@@ -1,0 +1,198 @@
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import {
+  type SnackRequestStatus,
+  toSnackRequest,
+  type SnackRequestRow,
+  isValidSnackRequestStatus,
+} from "@/lib/snackRequests";
+
+type RequestPayload = {
+  snackName?: unknown;
+  details?: unknown;
+  source?: unknown;
+};
+
+type ProfileRole = {
+  role: string | null;
+};
+
+type ProfileRecord = ProfileRole & {
+  full_name?: string | null;
+  email?: string | null;
+};
+
+const MAX_SNACK_NAME_LENGTH = 120;
+const MAX_TEXT_FIELD_LENGTH = 500;
+
+function sanitiseText(value: unknown, maxLength: number) {
+  if (typeof value !== "string") {
+    return "";
+  }
+
+  return value.trim().slice(0, maxLength);
+}
+
+async function getProfileRole(supabase: ReturnType<typeof createRouteHandlerClient>) {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return { user: null, role: null, error } as const;
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("role, full_name, email")
+    .eq("id", user.id)
+    .maybeSingle<ProfileRecord>();
+
+  if (profileError) {
+    return { user, role: null, error: profileError } as const;
+  }
+
+  return { user, role: profile?.role ?? null, profile } as const;
+}
+
+function ensureValidStatuses(value: string | null): SnackRequestStatus[] {
+  if (!value) return [];
+
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item): item is SnackRequestStatus => isValidSnackRequestStatus(item));
+}
+
+export async function GET(request: NextRequest) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const { searchParams } = request.nextUrl;
+
+  const { user, role, profile, error } = await getProfileRole(supabase);
+
+  if (error) {
+    console.error("[snack-requests][GET] Failed to resolve profile", error);
+    return NextResponse.json(
+      { error: "We couldn’t verify your account. Please sign in again." },
+      { status: 401 }
+    );
+  }
+
+  if (!user) {
+    return NextResponse.json(
+      { error: "You must be signed in to view snack requests." },
+      { status: 401 }
+    );
+  }
+
+  const statusFilters = ensureValidStatuses(searchParams.get("status"));
+
+  let query = supabase
+    .from("snack_requests")
+    .select(
+      "id, user_id, snack_name, details, source, status, created_at, updated_at, profiles(full_name, email)"
+    )
+    .order("created_at", { ascending: false });
+
+  if (statusFilters.length > 0) {
+    query = query.in("status", statusFilters);
+  }
+
+  if (role === "admin") {
+    // Admins can view all requests, optionally filtered by status
+  } else {
+    query = query.eq("user_id", user.id);
+  }
+
+  const { data, error: selectError } = await query;
+
+  if (selectError) {
+    console.error("[snack-requests][GET] Failed to fetch requests", selectError);
+    return NextResponse.json(
+      { error: "We couldn’t load snack requests right now. Please try again." },
+      { status: 500 }
+    );
+  }
+
+  const requests = (data ?? []).map((row) =>
+    toSnackRequest(row as SnackRequestRow)
+  );
+
+  return NextResponse.json({
+    data: requests,
+    viewer: {
+      id: user.id,
+      role: role ?? null,
+      full_name: profile?.full_name ?? null,
+      email: profile?.email ?? null,
+    },
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return NextResponse.json(
+      { error: "You must be signed in to submit a snack request." },
+      { status: 401 }
+    );
+  }
+
+  let payload: RequestPayload;
+  try {
+    payload = (await request.json()) as RequestPayload;
+  } catch (err) {
+    console.error("[snack-requests][POST] Invalid JSON payload", err);
+    return NextResponse.json(
+      { error: "We couldn’t read your request. Please try again." },
+      { status: 400 }
+    );
+  }
+
+  const snackName = sanitiseText(payload.snackName, MAX_SNACK_NAME_LENGTH);
+  const details = sanitiseText(payload.details, MAX_TEXT_FIELD_LENGTH);
+  const source = sanitiseText(payload.source, MAX_TEXT_FIELD_LENGTH);
+
+  if (!snackName) {
+    return NextResponse.json(
+      { error: "Please share the snack name before submitting." },
+      { status: 400 }
+    );
+  }
+
+  const insertPayload = {
+    user_id: user.id,
+    snack_name: snackName,
+    details: details || null,
+    source: source || null,
+  };
+
+  const { data, error: insertError } = await supabase
+    .from("snack_requests")
+    .insert(insertPayload)
+    .select(
+      "id, user_id, snack_name, details, source, status, created_at, updated_at, profiles(full_name, email)"
+    )
+    .single();
+
+  if (insertError || !data) {
+    console.error("[snack-requests][POST] Failed to insert request", insertError);
+    return NextResponse.json(
+      { error: "We couldn’t save your snack request. Please try again." },
+      { status: 500 }
+    );
+  }
+
+  const requestRecord = toSnackRequest(data as SnackRequestRow);
+
+  return NextResponse.json({ data: requestRecord }, { status: 201 });
+}
+
+export const dynamic = "force-dynamic";

--- a/src/app/requests/page.tsx
+++ b/src/app/requests/page.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+import LoadingState from "@/components/LoadingState";
+import { useAuth } from "@/lib/hooks/useAuth";
+import {
+  SNACK_REQUEST_STATUS_BADGE_CLASSES,
+  SNACK_REQUEST_STATUS_LABELS,
+  type SnackRequestWithProfile,
+} from "@/lib/snackRequests";
+
+type SnackRequestResponse = {
+  data: SnackRequestWithProfile[];
+};
+
+type SnackRequestPostResponse = {
+  data: SnackRequestWithProfile;
+};
+
+export default function SnackRequestsPage() {
+  const { user, loading: authLoading, error: authError, profile } = useAuth();
+  const [requests, setRequests] = useState<SnackRequestWithProfile[]>([]);
+  const [dataLoading, setDataLoading] = useState(false);
+  const [dataError, setDataError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState<string | null>(null);
+
+  const fetchRequests = useCallback(async () => {
+    if (!user) {
+      setRequests([]);
+      return;
+    }
+
+    setDataLoading(true);
+    setDataError(null);
+
+    try {
+      const response = await fetch("/api/snack-requests");
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(body?.error || "We couldn’t load your snack ideas.");
+      }
+
+      const body = (await response.json()) as SnackRequestResponse;
+      setRequests(body.data ?? []);
+    } catch (err) {
+      console.error("[requests] Failed to fetch", err);
+      setDataError(
+        err instanceof Error
+          ? err.message
+          : "We couldn’t load your snack ideas. Please try again."
+      );
+    } finally {
+      setDataLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (user) {
+      fetchRequests().catch((err) => {
+        console.error("[requests] initial load failed", err);
+      });
+    }
+  }, [user, fetchRequests]);
+
+  const pendingCount = useMemo(
+    () => requests.filter((request) => request.status === "pending").length,
+    [requests]
+  );
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!user || submitting) return;
+
+    setSubmitting(true);
+    setSubmitError(null);
+    setSubmitSuccess(null);
+
+    const formData = new FormData(event.currentTarget);
+    const payload = {
+      snackName: (formData.get("snackName") as string | null) ?? "",
+      details: (formData.get("details") as string | null) ?? "",
+      source: (formData.get("source") as string | null) ?? "",
+    };
+
+    try {
+      const response = await fetch("/api/snack-requests", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        throw new Error(body?.error || "We couldn’t save that idea. Try again.");
+      }
+
+      const body = (await response.json()) as SnackRequestPostResponse;
+
+      setRequests((prev) => [body.data, ...prev]);
+      setSubmitSuccess("Thanks! Your idea is now in Sandy’s queue.");
+      event.currentTarget.reset();
+    } catch (err) {
+      console.error("[requests] submit failed", err);
+      setSubmitError(
+        err instanceof Error
+          ? err.message
+          : "We couldn’t save that idea. Please try again."
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (authLoading) {
+    return (
+      <LoadingState
+        title="Loading the request counter"
+        message="Collecting your snack suggestions."
+      />
+    );
+  }
+
+  if (authError) {
+    return (
+      <div className="min-h-screen bg-orange-50 flex items-center justify-center p-4">
+        <div className="max-w-md w-full bg-white rounded-2xl p-8 shadow-lg text-center">
+          <div className="text-4xl mb-4">😵‍💫</div>
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">We hit a snack snag</h1>
+          <p className="text-gray-600 mb-6">{authError}</p>
+          <a
+            href="/join"
+            className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-orange-500 text-white font-medium hover:bg-orange-600 transition"
+          >
+            Head back to sign in
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="min-h-screen bg-orange-50 flex items-center justify-center p-4">
+        <div className="max-w-md w-full bg-white rounded-2xl p-8 shadow-lg text-center">
+          <div className="text-4xl mb-4">🔐</div>
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">Sign in required</h1>
+          <p className="text-gray-600 mb-6">
+            Sign in to pitch your next snack idea to Sandy’s crew.
+          </p>
+          <a
+            href="/join"
+            className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-orange-500 text-white font-medium hover:bg-orange-600 transition"
+          >
+            Go to sign in
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4">
+      <div className="max-w-4xl mx-auto space-y-8">
+        <div className="bg-white rounded-2xl p-8 shadow-sm">
+          <p className="text-sm uppercase tracking-wide text-gray-500">Snack wishlist</p>
+          <h1 className="text-3xl font-bold text-gray-900 mt-2">
+            Share a snack idea, {profile?.full_name || "snack fan"}!
+          </h1>
+          <p className="text-gray-600 mt-2">
+            Tell Sandy what treats the office should try next. We’ll keep you posted as your idea moves through the queue.
+          </p>
+        </div>
+
+        <div className="bg-white rounded-2xl p-8 shadow-sm">
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">Submit a new request</h2>
+          <p className="text-sm text-gray-500 mb-6">
+            Give us the details so we can track it down.
+          </p>
+
+          <form onSubmit={handleSubmit} className="space-y-5">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2" htmlFor="snackName">
+                Snack name
+              </label>
+              <input
+                id="snackName"
+                name="snackName"
+                type="text"
+                required
+                placeholder="e.g. Chili Lime Plantain Chips"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-200"
+                disabled={submitting}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2" htmlFor="details">
+                What makes it special?
+              </label>
+              <textarea
+                id="details"
+                name="details"
+                rows={4}
+                placeholder="Share the flavor notes, why it’s a hit, or who would love it."
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-200"
+                disabled={submitting}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2" htmlFor="source">
+                Where can we find it? (optional)
+              </label>
+              <input
+                id="source"
+                name="source"
+                type="text"
+                placeholder="Drop a store, site, or link."
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-200"
+                disabled={submitting}
+              />
+            </div>
+
+            {submitError && (
+              <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                {submitError}
+              </div>
+            )}
+
+            {submitSuccess && (
+              <div className="rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-green-700">
+                {submitSuccess}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex items-center justify-center gap-2 rounded-lg bg-orange-500 px-4 py-2 font-medium text-white transition hover:bg-orange-600 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {submitting ? (
+                <>
+                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                  Sending idea...
+                </>
+              ) : (
+                <>Submit request</>
+              )}
+            </button>
+          </form>
+        </div>
+
+        <div className="bg-white rounded-2xl p-8 shadow-sm">
+          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between mb-6">
+            <div>
+              <h2 className="text-xl font-semibold text-gray-900">Your requests</h2>
+              <p className="text-sm text-gray-500">
+                {pendingCount > 0
+                  ? `${pendingCount} waiting for Sandy’s review.`
+                  : "No pending requests right now."}
+              </p>
+            </div>
+            <button
+              onClick={() => fetchRequests()}
+              className="inline-flex items-center gap-2 rounded-lg border border-orange-200 bg-white px-3 py-2 text-sm font-medium text-orange-600 transition hover:border-orange-300 hover:text-orange-700"
+              disabled={dataLoading}
+            >
+              {dataLoading ? (
+                <>
+                  <span className="h-4 w-4 animate-spin rounded-full border-2 border-orange-200 border-t-orange-500" />
+                  Refreshing
+                </>
+              ) : (
+                <>
+                  <span aria-hidden>⟳</span>
+                  Refresh list
+                </>
+              )}
+            </button>
+          </div>
+
+          {dataError && (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 mb-4">
+              {dataError}
+            </div>
+          )}
+
+          {dataLoading && requests.length === 0 ? (
+            <div className="text-sm text-gray-500">Loading your snack ideas...</div>
+          ) : requests.length === 0 ? (
+            <p className="text-sm text-gray-500">
+              You haven’t sent Sandy any snack ideas yet. Submit one above to get started!
+            </p>
+          ) : (
+            <div className="space-y-4">
+              {requests.map((request) => (
+                <div
+                  key={request.id}
+                  className="rounded-xl border border-gray-200 p-4 flex flex-col gap-3 md:flex-row md:items-start md:justify-between"
+                >
+                  <div className="flex-1">
+                    <div className="flex items-center gap-3 flex-wrap">
+                      <h3 className="text-lg font-semibold text-gray-900">
+                        {request.snack_name}
+                      </h3>
+                      <span
+                        className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${SNACK_REQUEST_STATUS_BADGE_CLASSES[request.status]}`}
+                      >
+                        {SNACK_REQUEST_STATUS_LABELS[request.status]}
+                      </span>
+                    </div>
+                    {request.details && (
+                      <p className="text-sm text-gray-600 mt-2 whitespace-pre-line">
+                        {request.details}
+                      </p>
+                    )}
+                    {request.source && (
+                      <p className="text-xs text-gray-500 mt-2">
+                        <span className="font-medium text-gray-700">Where to find it:</span> {request.source}
+                      </p>
+                    )}
+                    <p className="text-xs text-gray-400 mt-3">
+                      Submitted {new Date(request.created_at).toLocaleString()}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/snackRequests.ts
+++ b/src/lib/snackRequests.ts
@@ -1,0 +1,80 @@
+export const SNACK_REQUEST_STATUSES = [
+  "pending",
+  "accepted",
+  "fulfilled",
+  "declined",
+] as const;
+
+export type SnackRequestStatus = (typeof SNACK_REQUEST_STATUSES)[number];
+
+export function isValidSnackRequestStatus(value: unknown): value is SnackRequestStatus {
+  return typeof value === "string" && (SNACK_REQUEST_STATUSES as readonly string[]).includes(value);
+}
+
+export const SNACK_REQUEST_STATUS_LABELS: Record<SnackRequestStatus, string> = {
+  pending: "Pending review",
+  accepted: "Accepted",
+  fulfilled: "Fulfilled",
+  declined: "Declined",
+};
+
+export const SNACK_REQUEST_STATUS_SHORT_LABELS: Record<SnackRequestStatus, string> = {
+  pending: "Pending",
+  accepted: "Accepted",
+  fulfilled: "Fulfilled",
+  declined: "Declined",
+};
+
+export const SNACK_REQUEST_STATUS_BADGE_CLASSES: Record<SnackRequestStatus, string> = {
+  pending: "bg-yellow-100 text-yellow-800 border border-yellow-200",
+  accepted: "bg-green-100 text-green-800 border border-green-200",
+  fulfilled: "bg-blue-100 text-blue-800 border border-blue-200",
+  declined: "bg-red-100 text-red-800 border border-red-200",
+};
+
+export type SnackRequest = {
+  id: string;
+  user_id: string;
+  snack_name: string;
+  details: string | null;
+  source: string | null;
+  status: SnackRequestStatus;
+  created_at: string;
+  updated_at: string;
+};
+
+export type SnackRequestWithProfile = SnackRequest & {
+  requester: {
+    full_name: string | null;
+    email: string | null;
+  } | null;
+};
+
+export type SnackRequestRow = Omit<SnackRequestWithProfile, "status" | "requester"> & {
+  status: string;
+  profiles?: {
+    full_name: string | null;
+    email: string | null;
+  } | null;
+};
+
+export function toSnackRequest(row: SnackRequestRow): SnackRequestWithProfile {
+  const status = isValidSnackRequestStatus(row.status) ? row.status : "pending";
+
+  return {
+    id: row.id,
+    user_id: row.user_id,
+    snack_name: row.snack_name,
+    details: row.details ?? null,
+    source: row.source ?? null,
+    status,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    requester: row.profiles
+      ? {
+          full_name: row.profiles.full_name ?? null,
+          email: row.profiles.email ?? null,
+        }
+      : null,
+  };
+}

--- a/supabase/migrations/20240227000000_create_snack_requests.sql
+++ b/supabase/migrations/20240227000000_create_snack_requests.sql
@@ -1,0 +1,14 @@
+-- Create table to capture member-submitted snack requests
+CREATE TABLE IF NOT EXISTS public.snack_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES public.profiles (id) ON DELETE CASCADE,
+  snack_name TEXT NOT NULL,
+  details TEXT,
+  source TEXT,
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'accepted', 'fulfilled', 'declined')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now()),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS snack_requests_user_id_idx ON public.snack_requests (user_id);
+CREATE INDEX IF NOT EXISTS snack_requests_status_idx ON public.snack_requests (status);


### PR DESCRIPTION
## Summary
- add a Supabase migration and shared helpers for snack request tracking
- expose snack request APIs plus a protected member submission page
- extend the admin dashboard with snack request filters and status updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ce124f32248331baca2760b927d1f2